### PR TITLE
set file_size in read mode

### DIFF
--- a/ecpprog/ecpprog.c
+++ b/ecpprog/ecpprog.c
@@ -867,6 +867,7 @@ int main(int argc, char **argv)
 			perror(0);
 			return EXIT_FAILURE;
 		}
+		file_size = read_size;
 	} else {
 		f = (strcmp(filename, "-") == 0) ? stdin : fopen(filename, "rb");
 		if (f == NULL) {


### PR DESCRIPTION
Currently it stays set to -1 and ecpprog reports e.g. "reading..    4190208/4294967295" (the latter number being 0xFFFFFFFF)