### PR TITLE
clkdiv: added clkdiv

### DIFF
--- a/ecpprog/jtag.h
+++ b/ecpprog/jtag.h
@@ -34,7 +34,7 @@ typedef enum e_TAPState
 /**
  * Performs the start-of-day tasks necessary to talk JTAG to our FPGA.
  */
-void jtag_init(int ifnum, const char *devstr, bool slow_clock);
+void jtag_init(int ifnum, const char *devstr, int clkdiv);
 
 
 /**

--- a/ecpprog/jtag_tap.c
+++ b/ecpprog/jtag_tap.c
@@ -130,9 +130,9 @@ void jtag_deinit(){
 /**
  * Performs any start-of-day tasks necessary to talk JTAG to our FPGA.
  */
-void jtag_init(int ifnum, const char *devstr, bool slow_clock)
+void jtag_init(int ifnum, const char *devstr, int clkdiv)
 {
-	mpsse_init(ifnum, devstr, slow_clock);
+	mpsse_init(ifnum, devstr, clkdiv);
 
 	jtag_set_current_state(STATE_TEST_LOGIC_RESET);
     jtag_go_to_state(STATE_TEST_LOGIC_RESET);
@@ -200,9 +200,6 @@ static void jtag_shift_bytes(
 	}
 	//printf("jtag_shift_bytes(0x%08x,0x%08x,%u,%s);\n",input_data, output_data, data_bits, must_end ? "true" : "false");
 	uint32_t byte_count = data_bits / 8;
-
-
-
 	data[0] = MC_DATA_OUT | MC_DATA_IN | MC_DATA_LSB | MC_DATA_OCN;
 	data[1] = (byte_count - 1); 
 	data[2] = (byte_count - 1) >> 8;        

--- a/ecpprog/mpsse.c
+++ b/ecpprog/mpsse.c
@@ -140,7 +140,7 @@ void mpsse_xfer(uint8_t* data_buffer, uint16_t send_length, uint16_t receive_len
 	}
 }
 
-void mpsse_init(int ifnum, const char *devstr, bool slow_clock)
+void mpsse_init(int ifnum, const char *devstr, int clkdiv)
 {
 	enum ftdi_interface ftdi_ifnum = INTERFACE_A;
 
@@ -216,17 +216,10 @@ void mpsse_init(int ifnum, const char *devstr, bool slow_clock)
 
 	mpsse_send_byte(MC_TCK_X5);
 
-	if (slow_clock) {
-		// set 50 kHz clock
-		mpsse_send_byte(MC_SET_CLK_DIV);
-		mpsse_send_byte(29);
-		mpsse_send_byte(0x00);
-	} else {
-		// set 6 MHz clock
-		mpsse_send_byte(MC_SET_CLK_DIV);
-		mpsse_send_byte(1);
-		mpsse_send_byte(0x00);
-	}
+        // set clock - actual clock is 6MHz/(clkdiv)
+        mpsse_send_byte(MC_SET_CLK_DIV);
+        mpsse_send_byte((clkdiv-1) & 0xff);
+        mpsse_send_byte((clkdiv-1) >> 8);
 
 	mpsse_send_byte(MC_SETB_LOW);
 	mpsse_send_byte(0x08); /* Value */

--- a/ecpprog/mpsse.h
+++ b/ecpprog/mpsse.h
@@ -113,7 +113,7 @@ int mpsse_readb_low(void);
 int mpsse_readb_high(void);
 void mpsse_send_dummy_bytes(uint8_t n);
 void mpsse_send_dummy_bit(void);
-void mpsse_init(int ifnum, const char *devstr, bool slow_clock);
+void mpsse_init(int ifnum, const char *devstr, int clkdiv);
 void mpsse_close(void);
 
 #endif /* MPSSE_H */


### PR DESCRIPTION
This change allows arbitrary divider values to be used for the 6MHz FTDI
SPI/JTAG clock.

I find that, on the Lattice NX Evaluation Board, the FTDI clock divider
needs to be set to a value of 3 or higher in order to program the flash
rom. This may be because the board uses an ES (Early Silicon/Engineering
Sample) CrossLink/NX-40. I see similar behavior with the Radiant
programmer where a divisor of 2 or higher is needed.

With a slower clock divider, ecpprog is also able to verify programmed
flash rom content.