### PR TITLE
Add LIFCL-33U IDCODE

### DIFF
--- a/ecpprog/lattice_cmds.h
+++ b/ecpprog/lattice_cmds.h
@@ -66,10 +66,12 @@ const struct device_id_pair ecp_devices[] =
 
 const struct device_id_pair nx_devices[] =
 {
-	/* Crosslink NX */
+	/* CrossLink NX */
 	{"LIFCL-17",    0x010F0043 },
 	{"LIFCL-40-ES", 0x010F1043 },
 	{"LIFCL-40",    0x110F1043 },
+	/* CrossLinkU NX */
+	{"LIFCL-33U",   0x010FB043 },
 	/* Certus NX */
 	{"LFD2NX-17",   0x310F0043 },
 	{"LFD2NX-40",   0x310F1043 },


### PR DESCRIPTION
This is the chip announced there, with an USB3 at 5 Gbit/s core in-silicon:
https://www.latticesemi.com/en/Blog/2023/09/25/20/31/Accelerate-USB-enabled-Designs-with-Lattice-CrossLinkU-NX-FPGAs

It is already [working great](https://tinyclunx33.tinyvision.ai/md_som_flash.html), so thank you for this tool!

#19 plays smoothly with new parts like this one by making IDCODE verification optional.