### PR TITLE
Add a Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,14 @@
 {
-  description = "";
+  description = "A basic driver for FTDI based JTAG probes (FT232H, FT2232H, FT4232H), to program Lattice ECP5/Nexus FPGAs.";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = {self, nixpkgs, flake-utils } :
+  outputs = { self, nixpkgs, flake-utils } :
   flake-utils.lib.eachDefaultSystem (system:
     let pkgs = import nixpkgs { inherit system; };
         ecpprog = {
           name = "ecpprog";
-          # packages = [];
           buildInputs = [ pkgs.clang pkgs.gnumake pkgs.libftdi1 ];
           nativeBuildInputs = [ pkgs.pkg-config ];
           src = ./ecpprog;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {self, nixpkgs, flake-utils } :
+  flake-utils.lib.eachDefaultSystem (system:
+    let pkgs = import nixpkgs { inherit system; };
+        ecpprog = {
+          name = "ecpprog";
+          # packages = [];
+          buildInputs = [ pkgs.clang pkgs.gnumake pkgs.libftdi1 ];
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          src = ./ecpprog;
+          buildPhase = ''
+            export DESTDIR=$out
+            export PREFIX=
+            make
+          '';
+          installPhase = ''
+            export DESTDIR=$out
+            export PREFIX=
+            make install
+          '';
+        };
+    in
+    {
+      devShells.default = pkgs.mkShell ecpprog;
+      packages.ecpprog = with pkgs; stdenv.mkDerivation ecpprog;
+      defaultPackage = with pkgs; stdenv.mkDerivation ecpprog;
+    }
+  );
+}


### PR DESCRIPTION
I'm running NixOS on my main machine, and I wanted to have access to `ecpprog` on it, as well as being able to use it in other Nix projects.

The flake contains a derivation for `ecpprog` (that you can build with `nix build`) and also provides a `devShell` (that you can use with `nix shell`).

It comes on top of the already existing `Makefile`, so as not to change the normal way to build/install it, merely providing an additional interface.