### PR TITLE
Add LIFCL-33U IDCODE.

### DIFF
--- a/ecpprog/lattice_cmds.h
+++ b/ecpprog/lattice_cmds.h
@@ -68,6 +68,7 @@ const struct device_id_pair nx_devices[] =
 {
 	/* Crosslink NX */
 	{"LIFCL-17",    0x010F0043 },
+	{"LIFCL-33U",   0x010FB043 },
 	{"LIFCL-40-ES", 0x010F1043 },
 	{"LIFCL-40",    0x110F1043 },
 	/* Certus NX */


### PR DESCRIPTION
```
ecpprog -k 2 top.bit 
init..
IDCODE: 0x010fb043 (LIFCL-33U)
NX Status Register: 0x0000110100000100
reset..
flash ID: 0x1F 0x42 0x16
file size: 770418
erase 64kB sector at 0x000000..
erase 64kB sector at 0x010000..
erase 64kB sector at 0x020000..
erase 64kB sector at 0x030000..
erase 64kB sector at 0x040000..
erase 64kB sector at 0x050000..
erase 64kB sector at 0x060000..
erase 64kB sector at 0x070000..
erase 64kB sector at 0x080000..
erase 64kB sector at 0x090000..
erase 64kB sector at 0x0A0000..
erase 64kB sector at 0x0B0000..
programming..  770418/770418
verify..       770418/770418  VERIFY OK
Bye.
```